### PR TITLE
Fix and allow inference on CPU.

### DIFF
--- a/maskdino/modeling/transformer_decoder/dino_decoder.py
+++ b/maskdino/modeling/transformer_decoder/dino_decoder.py
@@ -113,9 +113,10 @@ class TransformerDecoder(nn.Module):
             - valid_ratios/spatial_shapes: bs, nlevel, 2
         """
         output = tgt
+        device = tgt.device
 
         intermediate = []
-        reference_points = refpoints_unsigmoid.sigmoid()
+        reference_points = refpoints_unsigmoid.sigmoid().to(device)
         ref_points = [reference_points]
 
         for layer_id, layer in enumerate(self.layers):
@@ -151,7 +152,7 @@ class TransformerDecoder(nn.Module):
             # iter update
             if self.bbox_embed is not None:
                 reference_before_sigmoid = inverse_sigmoid(reference_points)
-                delta_unsig = self.bbox_embed[layer_id](output)
+                delta_unsig = self.bbox_embed[layer_id](output).to(device)
                 outputs_unsig = delta_unsig + reference_before_sigmoid
                 new_reference_points = outputs_unsig.sigmoid()
 

--- a/maskdino/modeling/transformer_decoder/maskdino_decoder.py
+++ b/maskdino/modeling/transformer_decoder/maskdino_decoder.py
@@ -346,13 +346,15 @@ class MaskDINODecoder(nn.Module):
         :param hs: content
         :param ref0: whether there are prediction from the first layer
         """
+        device = reference[0].device
+
         if ref0 is None:
             outputs_coord_list = []
         else:
-            outputs_coord_list = [ref0]
+            outputs_coord_list = [ref0.to(device)]
         for dec_lid, (layer_ref_sig, layer_bbox_embed, layer_hs) in enumerate(zip(reference[:-1], self.bbox_embed, hs)):
-            layer_delta_unsig = layer_bbox_embed(layer_hs)
-            layer_outputs_unsig = layer_delta_unsig + inverse_sigmoid(layer_ref_sig)
+            layer_delta_unsig = layer_bbox_embed(layer_hs).to(device)
+            layer_outputs_unsig = layer_delta_unsig + inverse_sigmoid(layer_ref_sig).to(device)
             layer_outputs_unsig = layer_outputs_unsig.sigmoid()
             outputs_coord_list.append(layer_outputs_unsig)
         outputs_coord_list = torch.stack(outputs_coord_list)


### PR DESCRIPTION
This pull requests allows to run inference on CPU( GPU keeps working fine).

If the model is set to CPU/GPU, it'll detect it properly and do the necessary conversions. So it's 100% backwards compatible.

It fixes this issue:

https://github.com/IDEA-Research/MaskDINO/issues/67